### PR TITLE
Add files via upload

### DIFF
--- a/fix_csv.py
+++ b/fix_csv.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """
 Created on Thu Mar  5 13:57:19 2020
-
 @author: Charles Ajah
 """
 
@@ -11,10 +10,10 @@ import argparse
 ap=argparse.ArgumentParser()
 
 #define the arguments for the parser
-ap.add_argument("-a", "--in-delimeter", required=True)
-ap.add_argument("-b", "--in-quote", required=True, help="You ,ust supply Second operand")
+ap.add_argument("-a", "--in_delimeter", required=True)
+ap.add_argument("-b", "--in_quote", required=True)
 args = vars(ap.parse_args())
 
 
 #print("Sum is {}".format(int(args['-a']) + int(args['-b'])))
-print("Sum is {}".format(int(args['in-delimeter']) + int(args['in-quote'])))
+print("Sum is {}".format(int(args['in_delimeter']) + int(args['in_quote'])))


### PR DESCRIPTION
replaced the optional long form arguments in-delimeter and in-quote with the underscore equivalents in_delimeter and in_quote. Apparently ArgumentParser does not like hyphens as option arguments